### PR TITLE
Use Python Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
       - run:
           name: Install Vyper
           command: |
-            pip install --user vyper
+            sudo pip install vyper
       - install_deps
       - run:
           name: Run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
       - run:
           name: Install Vyper
           command: |
-            sudo pip install vyper
+            pip install vyper
       - install_deps
       - run:
           name: Run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,7 @@ commands:
       - run:
           name: Install Vyper
           command: |
-            pip3.7 install vyper
-            vyper --version
+            pip install vyper
       # Download and cache dependencies
       - restore_cache:
           name: Restore node_modules
@@ -38,10 +37,6 @@ jobs:
     executor: default
     steps:
       - checkout
-      - run:
-          name: Install Vyper
-          command: |
-            pip install vyper
       - install_deps
       - run:
           name: Run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,14 +4,10 @@
 
 version: 2.1
 
-
-orbs:
-    core: ren/core@0.0.1
-
 executors:
   default:
     docker:
-      - image: circleci/node:10.16
+      - image: nikolaik/python-nodejs:python3.6-nodejs10
     working_directory: ~/contracts
 
 commands:
@@ -37,7 +33,10 @@ jobs:
     executor: default
     steps:
       - checkout
-      - core/install_vyper
+      - run:
+          name: Install Vyper
+          command: |
+            pip install --user vyper
       - install_deps
       - run:
           name: Run tests


### PR DESCRIPTION
This PR changes the docker image to use one that contains Python so manual installation of Python is no longer necessary. This speeds up the testing by a considerable margin, from 3-5 minutes to <2 minutes.